### PR TITLE
fix: add ConfigurationRecorder and DeliveryStream resources to CFN template

### DIFF
--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -1,7 +1,7 @@
 project:
   name: wordpress-single-instance
   regions:
-    - us-east-1
+    - eu-west-1
 tests:
   default:
     template: wordpress/wordpress-single-instance.yaml

--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -1,7 +1,7 @@
 project:
   name: wordpress-single-instance
   regions:
-    - eu-west-1
+    - us-east-1
 tests:
   default:
     template: wordpress/wordpress-single-instance.yaml

--- a/pipeline/basic-pipeline.yaml
+++ b/pipeline/basic-pipeline.yaml
@@ -269,6 +269,7 @@ Resources:
           Protocol: email
 
   AWSConfigRule:
+    DependsOn: ConfigRecorder
     Type: AWS::Config::ConfigRule
     Properties:
       ConfigRuleName: vpc-default-security-group-closed
@@ -341,3 +342,47 @@ Resources:
           StaticValue:
             Values:
               - Ref: ConfigSNSTopic
+
+  ConfigRecorder:
+    Type: AWS::Config::ConfigurationRecorder
+    Properties: 
+      RoleARN: !GetAtt ConfigRecorderRole.Arn
+
+  ConfigRecorderRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: config.amazonaws.com
+            Action:
+              - "sts:AssumeRole"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWS_ConfigRole
+      Policies:
+      - PolicyName: root
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action: s3:GetBucketAcl
+            Resource: !Join ['', ['arn:aws:s3:::', !Ref 'ConfigBucket']]
+          - Effect: Allow
+            Action: s3:PutObject
+            Resource: !Join ['', ['arn:aws:s3:::', !Ref 'ConfigBucket', /AWSLogs/, !Ref 'AWS::AccountId', /*]]
+            Condition:
+              StringEquals:
+                s3:x-amz-acl: bucket-owner-full-control
+          - Effect: Allow
+            Action: config:Put*
+            Resource: '*'
+     
+  ConfigBucket:
+    Type: AWS::S3::Bucket
+     
+  ConfigDeliveryChannel:
+    Type: AWS::Config::DeliveryChannel
+    Properties: 
+      S3BucketName: !Ref "ConfigBucket"


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Deploying the `basic-pipeline.yaml` CloudFormation template was causing errors in new environments where AWS Config had not yet been initialized, since a ConfigurationRecorder and DeliveryStream would not yet exist in that scenario and the template contains a ConfigRule resource. This change adds those resources to the template so that the deployment is successful. This could perhaps cause an issue in environments where Config has already been initialized, but this hasn't been tested.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
